### PR TITLE
Removes --asroot for pacman v4.2.0 compatibiliity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ REQUIREMENTS
 
 Platform: ArchLinux. Pacman is not relevant on other platforms.
 
+ATTRIBUTES
+==========
+
+| Attribute                   | Default                                   | Description                                             |
+|-----------------------------|-------------------------------------------|---------------------------------------------------------|
+| `node[:pacman][:build_dir]` | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
+
 RESOURCES
 =========
 
@@ -33,7 +40,7 @@ Use the `pacman_aur` resource to install packages from ArchLinux's AUR repositor
 ### Parameters:
 
 * version - hardcode a version
-* builddir - specify an alternate build directory, defaults to `Chef::Config[:file_cache_path]/builds`.
+* builddir - specify an alternate build directory, defaults to `node[:pacman][:build_dir]`.
 * options - pass arbitrary options to the pacman command.
 * `pkgbuild_src` - whether to use an included PKGBUILD file, put the PKGBUILD file in in the `files/default` directory.
 * patches - array of patch names, as files in `files/default` that should be applied for the package.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Platform: ArchLinux. Pacman is not relevant on other platforms.
 ATTRIBUTES
 ==========
 
-| Attribute                   | Default                                   | Description                                             |
-|-----------------------------|-------------------------------------------|---------------------------------------------------------|
-| `node[:pacman][:build_dir]` | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
+| Attribute                    | Default                                   | Description                                             |
+|------------------------------|-------------------------------------------|---------------------------------------------------------|
+| `node[:pacman][:build_dir]`  | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
+| `node[:pacman][:build_user]` | `root`                                    | The user that will build AUR packages.                  |
 
 RESOURCES
 =========

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ATTRIBUTES
 | Attribute                    | Default                                   | Description                                             |
 |------------------------------|-------------------------------------------|---------------------------------------------------------|
 | `node[:pacman][:build_dir]`  | `#{Chef:Config[:file_cache_path]}/builds` | The default directory where AUR packages will be built. |
-| `node[:pacman][:build_user]` | `root`                                    | The user that will build AUR packages.                  |
+| `node[:pacman][:build_user]` | `nobody`                                    | The user that will build AUR packages.                  |
 
 RESOURCES
 =========

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 #
 
 default[:pacman][:build_dir] = "#{Chef::Config[:file_cache_path]}/builds"
+default[:pacman][:build_user] = "root"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,4 +18,4 @@
 #
 
 default[:pacman][:build_dir] = "#{Chef::Config[:file_cache_path]}/builds"
-default[:pacman][:build_user] = "root"
+default[:pacman][:build_user] = "nobody"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: pacman
-# Resource:: group
+# Attribute:: default
 #
 # Copyright:: 2010, Opscode, Inc <legal@opscode.com>
 #
@@ -17,14 +17,4 @@
 # limitations under the License.
 #
 
-actions :build, :install
-
-default_action :install
-
-attribute :package_name, :name_attribute => true
-attribute :version, :default => nil
-attribute :builddir, :default => node[:pacman][:build_dir]
-attribute :options, :kind_of => String
-attribute :pkgbuild_src, :default => false
-attribute :patches, :kind_of => Array, :default => []
-attribute :exists, :default => false
+default[:pacman][:build_dir] = "#{Chef::Config[:file_cache_path]}/builds"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "jesse@techno-geeks.org"
 license          "Apache 2.0"
 description      "Updates package list for pacman and has LWRP for pacman groups"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.1.1"
+version          "1.2.0"

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -123,7 +123,7 @@ def get_pkg_version
         if line.match 'any'
           a = 'any'
         else
-          a = node.kernel.machine
+          a = node[:kernel][:machine]
         end
       end
     end

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -102,8 +102,9 @@ action :build do
 end
 
 action :install do
-  unless @aurpkg.exists
-    get_pkg_version
+  get_pkg_version
+
+  unless @aurpkg.exists && new_resource.version == @aurpkg.installed_version
     execute "install AUR package #{new_resource.name}-#{new_resource.version}" do
       command "pacman -U --noconfirm  --noprogressbar #{new_resource.builddir}/#{new_resource.name}/#{new_resource.name}-#{new_resource.version}.pkg.tar.xz"
     end
@@ -140,4 +141,7 @@ def load_current_resource
   p = shell_out("pacman -Qi #{new_resource.package_name}")
   exists = p.stdout.include?(new_resource.package_name)
   @aurpkg.exists(exists)
+  p.stdout.match(/Version +: ([\w.-]+).+Architecture +: (\w+)/m) do |match|
+    @aurpkg.installed_version("#{match[1]}-#{match[2]}")
+  end
 end

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -88,8 +88,7 @@ action :build do
     end
 
     Chef::Log.debug("Building package #{new_resource.name}")
-    as_root = node[:pacman][:build_user] == "root" ? " --asroot" : ""
-    em = execute "makepkg -s --noconfirm#{as_root}" do
+    em = execute "makepkg -s --noconfirm" do
       cwd ::File.join(new_resource.builddir, new_resource.name)
       creates aurfile
       user node[:pacman][:build_user]

--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -30,8 +30,8 @@ action :build do
   unless ::File.exists?(aurfile)
     Chef::Log.debug("Creating build directory")
     d = directory new_resource.builddir do
-      owner "root"
-      group "root"
+      owner node[:pacman][:build_user]
+      group node[:pacman][:build_user]
       mode 0755
       action :nothing
     end
@@ -40,8 +40,8 @@ action :build do
     Chef::Log.debug("Retrieving source for #{new_resource.name}")
     r = remote_file "#{new_resource.builddir}/#{new_resource.name}.tar.gz" do
       source "https://aur.archlinux.org/packages/#{package_namespace}/#{new_resource.name}/#{new_resource.name}.tar.gz"
-      owner "root"
-      group "root"
+      owner node[:pacman][:build_user]
+      group node[:pacman][:build_user]
       mode 0644
       action :nothing
     end
@@ -50,6 +50,8 @@ action :build do
     Chef::Log.debug("Untarring source package for #{new_resource.name}")
     e = execute "tar -xf #{new_resource.name}.tar.gz" do
       cwd new_resource.builddir
+      user node[:pacman][:build_user]
+      group node[:pacman][:build_user]
       action :nothing
     end
     e.run_action(:run)
@@ -58,8 +60,8 @@ action :build do
       Chef::Log.debug("Replacing PKGBUILD with custom version")
       pkgb = cookbook_file "#{new_resource.builddir}/#{new_resource.name}/PKGBUILD" do
         source "PKGBUILD"
-        owner "root"
-        group "root"
+        owner node[:pacman][:build_user]
+        group node[:pacman][:build_user]
         mode 0644
         action :nothing
       end
@@ -86,9 +88,12 @@ action :build do
     end
 
     Chef::Log.debug("Building package #{new_resource.name}")
-    em = execute "makepkg -s --asroot --noconfirm" do
+    as_root = node[:pacman][:build_user] == "root" ? " --asroot" : ""
+    em = execute "makepkg -s --noconfirm#{as_root}" do
       cwd ::File.join(new_resource.builddir, new_resource.name)
       creates aurfile
+      user node[:pacman][:build_user]
+      group node[:pacman][:build_user]
       action :nothing
     end
     em.run_action(:run)

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -19,12 +19,13 @@
 
 require 'chef/mixin/shell_out'
 require 'chef/mixin/language'
+include Chef::Mixin::Command
 include Chef::Mixin::ShellOut
 
 action :install do
   unless @pmgroup.exists
     run_command_with_systems_locale(
-      :command => "pacman --sync --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}"
+      :command => "pacman --sync --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{@new_resource.name}"
     )
     new_resource.updated_by_last_action(true)
   end
@@ -33,7 +34,7 @@ end
 action :remove do
   if @pmgroup.exists
     run_command_with_systems_locale(
-      :command => "pacman --remove --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{name}"
+      :command => "pacman --remove --noconfirm --noprogressbar#{expand_options(@new_resource.options)} #{@new_resource.name}"
     )
     new_resource.updated_by_last_action(true)
   end
@@ -47,4 +48,9 @@ def load_current_resource
   p = shell_out("pacman -Qg #{@new_resource.package_name}")
   exists = p.stdout.include?(@new_resource.package_name)
   @pmgroup.exists(exists)
+end
+
+# From Chef::Provider::Package
+def expand_options(options)
+  options ? " #{options}" : ""
 end

--- a/resources/aur.rb
+++ b/resources/aur.rb
@@ -28,3 +28,4 @@ attribute :options, :kind_of => String
 attribute :pkgbuild_src, :default => false
 attribute :patches, :kind_of => Array, :default => []
 attribute :exists, :default => false
+attribute :installed_version, :default => nil


### PR DESCRIPTION
Sets default pacman.build_user to `nobody` and removes --asroot option, which was removed from pacman in 4.2.0
