### PR TITLE
Fix method access to node attributes

### DIFF
--- a/providers/aur.rb
+++ b/providers/aur.rb
@@ -118,7 +118,7 @@ def get_pkg_version
         if line.match 'any'
           a = 'any'
         else
-          a = node.kernel.machine
+          a = node['kernel']['machine']
         end
       end
     end


### PR DESCRIPTION
Method access to node attributes will be removed in Chef 13, so this
switches to bracket syntax instead.

https://discourse.chef.io/t/chef-12-13-30-method-access-to-node-attributes-deprecation-warnings-on-template/9136