### PR TITLE
Added `pacman_packages` resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ http://aur.archlinux.org/
 `pacman_packages`
 -----------------
 
-Use the `pacman_packages` resource to install or remote multiple pacman packages at once.
+Use the `pacman_packages` resource to install or remove multiple pacman packages at once.
 
 ### Actions:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ Use the `pacman_aur` resource to install packages from ArchLinux's AUR repositor
 
 http://aur.archlinux.org/
 
+`pacman_packages`
+-----------------
+
+Use the `pacman_packages` resource to install or remote multiple pacman packages at once.
+
+### Actions:
+
+* :install - Installs the provided list of packages
+* :remove  - Uninstalls the provided list of packages
+
+### Parameters:
+
+* `packages`: Array of packages to install/remove.
+* `options`: String of options to add to the pacman command.
+
 USAGE
 =====
 

--- a/providers/packages.rb
+++ b/providers/packages.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: pacman
+# Provider:: group
+#
+# Copyright:: 2010, Opscode, Inc <legal@opscode.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/mixin/shell_out'
+require 'chef/mixin/language'
+require 'chef/mixin/command'
+include Chef::Mixin::Command
+
+action :install do
+  run_command_with_systems_locale(
+    :command => "pacman --sync --needed --noconfirm --noprogressbar #{@new_resource.options} #{@new_resource.packages.join(' ')}"
+  )
+  new_resource.updated_by_last_action(true)
+end
+
+action :remove do
+  run_command_with_systems_locale(
+    :command => "pacman --remove --noconfirm --noprogressbar #{@new_resource.options} #{@new_resource.packages.join(' ')}"
+  )
+  new_resource.updated_by_last_action(true)
+end

--- a/resources/packages.rb
+++ b/resources/packages.rb
@@ -23,4 +23,3 @@ default_action :install
 
 attribute :packages, Array, :name_attribute => true
 attribute :options, :kind_of => String
-attribute :exists, :default => false

--- a/resources/packages.rb
+++ b/resources/packages.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: pacman
+# Resource:: group
+#
+# Copyright:: 2010, Opscode, Inc <legal@opscode.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :install, :remove
+
+default_action :install
+
+attribute :packages, Array, :name_attribute => true
+attribute :options, :kind_of => String
+attribute :exists, :default => false


### PR DESCRIPTION
Added a `pacman_packages` resource which installs multiple packages at once, greatly increasing the speed of package installation.

Note: This is mostly a work-around for [an issue with the pacman_package resource](https://github.com/chef/chef/issues/5780), but this was way easier than updating the HWRP. I might give that a try at that sometime in the future, but I think this could be useful in the meantime.

Before:

```
zeal@drcid ~/chef/cookbooks $ time run-chef.sh -r 'pacman,base::x11'
Starting Chef Client, version 12.17.44
resolving cookbooks for run list: ["pacman", "base::x11"]
Synchronizing Cookbooks:
  - pacman (1.1.1)
  - base (0.1.0)
Installing Cookbook Gems:
Compiling Cookbooks...
Recipe: pacman::default
  * execute[pacman -Sy] action run
    - execute pacman -Sy
  Converging 36 resources
  * execute[pacman -Sy] action nothing (skipped due to action :nothing)
Recipe: base::x11
  * package[xorg-server] action upgrade (up to date)
  * package[xorg-xinit] action upgrade (up to date)
  * package[xorg-xrandr] action upgrade (up to date)
  * package[arandr] action upgrade (up to date)
  * package[pulseaudio] action upgrade (up to date)
  * package[alsa-utils] action upgrade (up to date)
  * package[ttf-arphic-ukai] action upgrade (up to date)
  * package[ttf-arphic-uming] action upgrade (up to date)
  * package[ttf-baekmuk] action upgrade (up to date)
  * package[ttf-bitstream-vera] action upgrade (up to date)
  * package[ttf-cheapskate] action upgrade (up to date)
  * package[ttf-dejavu] action upgrade (up to date)
  * package[ttf-freebanglafont] action upgrade (up to date)
  * package[ttf-freefont] action upgrade (up to date)
  * package[ttf-hannom] action upgrade (up to date)
  * package[ttf-indic-otf] action upgrade (up to date)
  * package[ttf-junicode] action upgrade (up to date)
  * package[ttf-khmer] action upgrade (up to date)
  * package[ttf-linux-libertine] action upgrade (up to date)
  * package[ttf-mph-2b-damase] action upgrade (up to date)
  * package[ttf-sazanami] action upgrade (up to date)
  * package[ttf-tibetan-machine] action upgrade (up to date)
  * package[ttf-ubraille] action upgrade (up to date)
  * package[ttf-anonymous-pro] action upgrade (up to date)
  * package[ttf-droid] action upgrade (up to date)
  * package[ttf-fira-mono] action upgrade (up to date)
  * package[ttf-fira-sans] action upgrade (up to date)
  * package[ttf-gentium] action upgrade (up to date)
  * package[ttf-hanazono] action upgrade (up to date)
  * package[ttf-inconsolata] action upgrade (up to date)
  * package[ttf-ionicons] action upgrade (up to date)
  * package[ttf-liberation] action upgrade (up to date)
  * package[ttf-linux-libertine-g] action upgrade (up to date)
  * package[ttf-symbola] action upgrade (up to date)
  * package[ttf-ubuntu-font-family] action upgrade (up to date)

Running handlers:
Running handlers complete
Chef Client finished, 1/37 resources updated in 16 seconds

real    0m17.605s
user    0m15.237s
sys     0m1.050s
```

After:

```
zeal@drcid ~/chef/cookbooks $ time run-chef.sh -r 'pacman,base::x11'
Starting Chef Client, version 12.17.44
resolving cookbooks for run list: ["pacman", "base::x11"]
Synchronizing Cookbooks:
  - pacman (1.1.1)
  - base (0.1.0)
Installing Cookbook Gems:
Compiling Cookbooks...
Recipe: pacman::default
  * execute[pacman -Sy] action run
    - execute pacman -Sy
  Converging 2 resources
  * execute[pacman -Sy] action nothing (skipped due to action :nothing)
Recipe: base::x11
  * pacman_packages[x11 utils] action install


Running handlers:
Running handlers complete
Chef Client finished, 2/3 resources updated in 01 seconds

real    0m2.124s
user    0m1.120s
sys     0m0.370s
```